### PR TITLE
Fix export to include trending items in data.json

### DIFF
--- a/src/ainews/export.py
+++ b/src/ainews/export.py
@@ -22,6 +22,17 @@ def export_items(
 
     since = datetime.now() - timedelta(hours=hours)
     items = get_items(conn, limit=500, since=since, min_score=min_score)
+
+    # Ensure dedicated-page items are included even if main feed limit cuts them off
+    dedicated_types = ["github_trending", "github_trending_history"]
+    existing_ids = {item.id for item in items}
+    for stype in dedicated_types:
+        extra = get_items(conn, limit=50, source_type=stype)
+        for item in extra:
+            if item.id not in existing_ids:
+                items.append(item)
+                existing_ids.add(item.id)
+
     all_tags = get_all_tags(conn)
     total = count_items(conn, since=since, min_score=min_score)
     conn.close()


### PR DESCRIPTION
## Summary
- The 500-item limit in `export_items()` could exclude trending repos from `data.json`
- Now separately fetches `github_trending` and `github_trending_history` items to guarantee they're included in the export for the static Vercel site

## Test plan
- [x] Export now produces 540 items (500 main + 40 trending backfill)
- [x] All 25 daily + 25 history trending repos present in data.json
- [x] All 14 tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)