### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.2.0 — 2026-03-09
+
+### Features
+
+- **GitHub Trending page** — trendshift.io scraper fetches top 25 trending repos daily, with two tabs: Daily Trending and Trending History (all-time most-featured repos)
+- **Static pages for Vercel** — Leaderboard, Events, CCC, and Trends pages exported as client-side JS for the static site
+- **CI: auto-export config** — new workflow re-exports `config.json` when `sources.yml` changes
+- **CI: static page check** — warns when a localhost template has no matching static page
+
+### Fixes
+
+- **Export includes dedicated-page items** — trending repos are now guaranteed in `data.json` even when the 500-item limit would otherwise exclude them
+
+### Infrastructure
+
+- Updated CLAUDE.md with static pages architecture and export documentation
+
 ## v0.1.0 — 2026-03-09
 
 First release of the AI News Filter — a personal news intelligence system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-news-filter"
-version = "0.1.0"
+version = "0.2.0"
 description = "Personal news intelligence system with principle-based filtering"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/ainews/api/app.py
+++ b/src/ainews/api/app.py
@@ -65,7 +65,7 @@ async def lifespan(app: FastAPI):
     scheduler.shutdown()
 
 
-app = FastAPI(title="AI News Filter", version="0.1.0", lifespan=lifespan)
+app = FastAPI(title="AI News Filter", version="0.2.0", lifespan=lifespan)
 app.include_router(admin_router)
 
 static_dir = str(settings.config_dir.parent / "static")


### PR DESCRIPTION
## Release v0.2.0

### Features
- **GitHub Trending page** — trendshift.io scraper with Daily Trending and Trending History tabs
- **Static pages for Vercel** — Leaderboard, Events, CCC, and Trends pages
- **CI: auto-export config** — re-exports config.json when sources.yml changes
- **CI: static page check** — warns when a template has no matching static page

### Fixes
- Export includes dedicated-page items in data.json

### Infrastructure
- Updated CLAUDE.md with static pages architecture

### PRs included
- #64 Add static pages for Vercel
- #65 Update CLAUDE.md with static pages and export changes
- #67 Add GitHub trending page via trendshift.io scraper
- #70 Fix export to include trending items in data.json


🤖 Generated with [Claude Code](https://claude.com/claude-code)