### PR TITLE
Fix admin page crash on github_trending config

### DIFF
--- a/src/ainews/sources/manager.py
+++ b/src/ainews/sources/manager.py
@@ -114,6 +114,8 @@ def get_source_display_name(source_type: str, entry: dict) -> str:
         return f"@{entry['handle']}"
     if source_type == "luma":
         return f"Luma: {entry['handle']}"
+    if source_type == "github_trending":
+        return "GitHub Trending"
     return entry.get("name", str(entry))
 
 
@@ -124,7 +126,11 @@ def get_all_sources_flat(config_dir: Path) -> list[dict]:
 
     sources = data.get("sources", {})
     for stype in SOURCE_FIELDS:
-        for i, entry in enumerate(sources.get(stype, []) or []):
+        entries = sources.get(stype, []) or []
+        if not isinstance(entries, list):
+            # Single-dict config (e.g. github_trending) — wrap in list
+            entries = [entries]
+        for i, entry in enumerate(entries):
             result.append(
                 {
                     "type": stype,


### PR DESCRIPTION
## Summary
- Fix `AttributeError` in `/admin/api/sources` endpoint that prevented the admin page from loading
- `github_trending` in `sources.yml` is a single dict (not a list of dicts), causing `get_all_sources_flat()` to iterate over dict keys as strings
- Added `isinstance` check to wrap non-list entries, and a display name handler for `github_trending`

## Test plan
- [x] `uv run pytest` — 14 tests pass
- [x] `uv run ruff check` — clean
- [x] Verified `/admin/api/sources` returns 200 with all 48 sources
- [ ] Load `/admin` in browser — table should render with all sources including GitHub Trending

🤖 Generated with [Claude Code](https://claude.com/claude-code)