### PR TITLE
Normalize github_trending config to standard list format

### DIFF
--- a/config/sources.yml
+++ b/config/sources.yml
@@ -139,7 +139,8 @@ sources:
   # === GitHub Trending (trendshift.io) ===
   # Scraped daily — top trending repos by engagement score.
   github_trending:
-    tags: [github, trending, open-source]
+    - name: trendshift.io
+      tags: [github, trending, open-source]
 
   # === Events (web scrapers) ===
   events:

--- a/src/ainews/ingest/github_trending.py
+++ b/src/ainews/ingest/github_trending.py
@@ -205,11 +205,11 @@ async def run_github_trending_ingestion(conn, sources_config: dict) -> int:
     from ainews.storage.db import ingest_items
 
     sources = sources_config.get("sources", {})
-    trending_config = sources.get("github_trending", {})
-    if not trending_config:
+    trending_entries = sources.get("github_trending", [])
+    if not trending_entries:
         return 0
 
-    tags = trending_config.get("tags", ["github", "trending", "open-source"])
+    tags = trending_entries[0].get("tags", ["github", "trending", "open-source"])
 
     total_new = 0
 

--- a/src/ainews/ingest/runner.py
+++ b/src/ainews/ingest/runner.py
@@ -66,14 +66,14 @@ async def fetch_single_source(
             return {"items_fetched": len(items), "new_items": new_count}
 
     # Check GitHub trending
-    trending_config = sources_config.get("sources", {}).get("github_trending", {})
-    if trending_config and "github" in source_name.lower() and "trend" in source_name.lower():
+    trending_entries = sources_config.get("sources", {}).get("github_trending", [])
+    if trending_entries and "github" in source_name.lower() and "trend" in source_name.lower():
         from ainews.ingest.github_trending import (
             fetch_github_trending,
             fetch_github_trending_history,
         )
 
-        tags = trending_config.get("tags", ["github", "trending", "open-source"])
+        tags = trending_entries[0].get("tags", ["github", "trending", "open-source"])
         total_fetched = 0
         total_new = 0
         items = await fetch_github_trending(tags=tags)

--- a/src/ainews/sources/manager.py
+++ b/src/ainews/sources/manager.py
@@ -15,7 +15,7 @@ SOURCE_FIELDS = {
     "xiaohongshu": {"required": ["user_id", "name"], "optional": ["tags"]},
     "luma": {"required": ["handle"], "optional": ["tags"]},
     "events": {"required": ["scraper", "name"], "optional": ["tags"]},
-    "github_trending": {"required": ["tags"], "optional": []},
+    "github_trending": {"required": ["name", "tags"], "optional": []},
     "leaderboard": {"required": ["url", "name"], "optional": ["tags"]},
     "event_links": {"required": ["url", "name"], "optional": ["tags"]},
     "arxiv_queries": {"required": ["query", "name"], "optional": ["tags"]},
@@ -114,8 +114,6 @@ def get_source_display_name(source_type: str, entry: dict) -> str:
         return f"@{entry['handle']}"
     if source_type == "luma":
         return f"Luma: {entry['handle']}"
-    if source_type == "github_trending":
-        return "GitHub Trending"
     return entry.get("name", str(entry))
 
 
@@ -126,11 +124,7 @@ def get_all_sources_flat(config_dir: Path) -> list[dict]:
 
     sources = data.get("sources", {})
     for stype in SOURCE_FIELDS:
-        entries = sources.get(stype, []) or []
-        if not isinstance(entries, list):
-            # Single-dict config (e.g. github_trending) — wrap in list
-            entries = [entries]
-        for i, entry in enumerate(entries):
+        for i, entry in enumerate(sources.get(stype, []) or []):
             result.append(
                 {
                     "type": stype,


### PR DESCRIPTION
## Summary
- Convert `github_trending` in `sources.yml` from a single dict to a list-of-dicts format (like all other source types), with name `trendshift.io`
- Remove the `isinstance` guard and hardcoded display name added in #74 — no longer needed
- Update `runner.py` and `github_trending.py` to read from `entries[0]` instead of treating the config as a bare dict

Closes #75

## Test plan
- [x] `uv run ruff check` — clean
- [x] `uv run pytest` — 14 tests pass
- [ ] Load `/admin` — verify GitHub Trending shows with name "trendshift.io"
- [ ] Run `uv run ainews fetch-source "GitHub"` — verify trending fetch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)