### PR TITLE
Fix github_trending indentation in sources.yml

### DIFF
--- a/config/sources.yml
+++ b/config/sources.yml
@@ -139,8 +139,8 @@ sources:
   # === GitHub Trending (trendshift.io) ===
   # Scraped daily — top trending repos by engagement score.
   github_trending:
-    - name: trendshift.io
-      tags: [github, trending, open-source]
+  - name: trendshift.io
+    tags: [github, trending, open-source]
 
   # === Events (web scrapers) ===
   events:


### PR DESCRIPTION
## Summary

- Fix YAML indentation for `github_trending` list items (4 spaces → 2 spaces) for consistency with the rest of the file.

## Test plan

- [ ] Config parses correctly: `uv run ainews list-sources`

🤖 Generated with [Claude Code](https://claude.com/claude-code)