### PR TITLE
Update stale uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ai-news-filter"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary
- `uv.lock` referenced version `0.1.0` while `pyproject.toml` is at `0.3.0`
- Regenerated lock file with `uv sync --python 3.12`

## Test plan
- [x] Only `uv.lock` changed in the diff
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)