### PR TITLE
Simplify README, move deployment details to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Personal news intelligence system that aggregates AI content from curated source
 |-------|-------|
 | ![Feeds](docs/screenshots/dashboard.png) | ![Admin](docs/screenshots/admin.png) |
 
-## Quick Start (Local)
-
-**Prerequisites:** [uv](https://docs.astral.sh/uv/getting-started/installation/) (Python package manager) and [Docker](https://docs.docker.com/get-docker/) (for RSSHub feeds). That's it.
+## Quick Start
 
 ```bash
 git clone https://github.com/YanCheng-go/ai-news-filter.git
@@ -16,96 +14,32 @@ cd ai-news-filter
 ./start.sh              # installs deps, starts RSSHub + Ollama, launches dashboard
 ```
 
-Open http://localhost:8000 — you're done. The script handles everything.
+Open http://localhost:8000 — you're done.
 
-**Options:**
 ```bash
-./start.sh --no-score   # skip Ollama (just fetch + display, no relevance scoring)
+./start.sh --no-score   # skip Ollama (just fetch + display)
 ./start.sh stop         # stop all services
 ```
 
-> **Optional:** Install [Ollama](https://ollama.ai) for local LLM scoring. Without it, `start.sh` still works — it just skips scoring.
+**Prerequisites:** [uv](https://docs.astral.sh/uv/getting-started/installation/) and [Docker](https://docs.docker.com/get-docker/). Optionally [Ollama](https://ollama.ai) for LLM scoring.
 
-## Three Modes
+## Deployment Modes
 
-### 1. Local (full-featured)
-Runs entirely on your machine — SQLite, Ollama, APScheduler, FastAPI dashboard. Full admin access.
+| Mode | Stack | Description |
+|------|-------|-------------|
+| **Local** | SQLite + Ollama + FastAPI | Full-featured, runs on your machine |
+| **Online Public** | Vercel + GitHub Actions | Static read-only dashboard, no backend needed |
+| **Online Login** | Supabase + Vercel | User accounts, per-user feeds, on-demand fetch |
 
-#### Twitter / X (local only)
-
-Twitter sources are only available in local mode. The fetcher reads your browser's session cookies directly — no API key required — but this approach is against X's Terms of Service, so it cannot be used in the cloud pipeline.
-
-**Prerequisites:**
-1. **Log in to X in Chrome** on the same machine. The fetcher reads `auth_token` and `ct0` cookies from your Chrome profile automatically via [`rookiepy`](https://github.com/thewh1teagle/rookiepy).
-2. **Install the `llm` extras** (includes `rookiepy`):
-   ```bash
-   uv sync --extra llm
-   ```
-3. **Verify the cookie setup:**
-   ```bash
-   uv run ainews twitter-setup
-   ```
-4. **Add Twitter sources** to `config/sources.yml` with `type: twitter` and `handle: username`.
-
-> **Why not in the cloud?** The method relies on scraping private GraphQL endpoints using your personal session cookies, which violates [X's Terms of Service](https://x.com/en/tos). Running it in a public CI pipeline would also expose your personal session. Use RSS-based alternatives (e.g. [nitter](https://github.com/zedeus/nitter) via RSSHub) for the cloud pipeline if you need Twitter content.
-
-### 2. Online Public (Vercel + GitHub Actions)
-Static read-only dashboard. GitHub Action fetches pre-defined feeds on a 2h cron, exports to `static/data.json`, and Vercel serves it. Data is kept for approximately one week.
-
-No database, no backend, no Ollama required. Scoring is optional (needs `ANTHROPIC_API_KEY`).
-
-**Setup:**
-1. Connect repo to Vercel (output directory: `static/`)
-2. Optionally add `ANTHROPIC_API_KEY` as a GitHub Actions secret for scoring
-3. Trigger the "Fetch & Export" workflow manually for the first run
-
-### 3. Online Login (Supabase + Vercel)
-Authenticated mode where users create accounts, manage their own source list, and fetch feeds on demand. Each user's data is fully isolated via Row Level Security.
-
-New users get a pre-defined source list but **no pre-fetched content** — items appear only after clicking "Fetch" in the admin UI. Sources can be added, edited, disabled, or removed.
-
-**Setup:**
-1. Create a [Supabase](https://supabase.com) project
-2. Run migrations: `supabase link --project-ref <ref>` then `supabase db push` (or paste `supabase/migrations/*.sql` in the SQL Editor)
-3. Set Vercel environment variables: `AINEWS_SUPABASE_URL`, `AINEWS_SUPABASE_KEY`, `AINEWS_SUPABASE_SERVICE_KEY`
-4. Optionally set `AINEWS_CORS_ORIGIN` to restrict cross-origin requests
-
-## Configuration
-
-- `config/sources.yml` — all feed sources (Twitter, YouTube, RSS, RSSHub, Luma, arXiv, GitHub Trending)
-- `config/principles.yml` — scoring principles and tier definitions
-- Environment variables prefixed `AINEWS_` override defaults (see `src/ainews/config.py`)
-- `AINEWS_SCORING=false` — disable Ollama scoring (fetch only)
-
-## Pages
-
-| Page | Local | Vercel | Description |
-|------|-------|--------|-------------|
-| Feeds | `/` | `index.html` | Main feed with filters, search, pagination |
-| Leaderboard | `/leaderboard` | `leaderboard.html` | AI benchmark and ranking sites |
-| Events | `/events` | `events.html` | Event calendars, Luma, tech events (3 tabs) |
-| Trends | `/trends` | `trends.html` | GitHub trending repos — daily + history (2 tabs) |
-| CCC | `/ccc` | `ccc.html` | Claude Code Changelogs |
-| About | `/about` | `about.html` | About page |
-| Admin | `/admin` | `admin.html` | Source management (local); read-only (public); source CRUD + fetch (login) |
-
-## Development
-
-See [docs/development.md](docs/development.md) for the full guide — dev environment setup (Nix + direnv or manual), project structure, commands, conventions, and workflow.
-
-```bash
-# Quick dev setup
-direnv allow   # if using Nix (recommended)
-uv sync        # install Python deps
-uv run ruff check src/ && uv run pytest  # lint + test
-```
+See [docs/deployment.md](docs/deployment.md) for setup instructions.
 
 ## Documentation
 
+- [docs/deployment.md](docs/deployment.md) — deployment modes, setup, configuration
 - [docs/development.md](docs/development.md) — dev setup, project structure, commands, conventions
 - [docs/architecture.md](docs/architecture.md) — data flow, design decisions, module map
 - [docs/sources.md](docs/sources.md) — how to configure and add sources
-- [docs/scoring.md](docs/scoring.md) — three principles, tiers, LLM prompt, score interpretation
+- [docs/scoring.md](docs/scoring.md) — scoring principles, tiers, LLM prompt
 
 ## Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,7 @@
 # Documentation
 
-This folder contains project documentation.
-
-## Contents
-
-- [architecture.md](architecture.md) — High-level architecture and design decisions
-
-## Other docs to consider adding
-
-- **API documentation** — endpoints, request/response formats, authentication
-- **Setup guides** — environment-specific setup (local, staging, production)
-- **Deployment instructions** — how to deploy, rollback, and verify
-- **Runbooks / troubleshooting** — common issues and how to resolve them
+- [deployment.md](deployment.md) — Deployment modes, setup instructions, configuration
+- [development.md](development.md) — Dev environment, project structure, commands, conventions
+- [architecture.md](architecture.md) — Data flow, design decisions, module map
+- [sources.md](sources.md) — Source types and configuration
+- [scoring.md](scoring.md) — Scoring principles, tiers, LLM prompt

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,86 @@
+# Deployment Modes
+
+Three ways to run the system — pick whichever fits your setup.
+
+## 1. Local (full-featured)
+
+Runs entirely on your machine — SQLite, Ollama, APScheduler, FastAPI dashboard. Full admin access.
+
+```bash
+./start.sh              # installs deps, starts RSSHub + Ollama, launches dashboard
+./start.sh --no-score   # skip Ollama (just fetch + display, no relevance scoring)
+./start.sh stop         # stop all services
+```
+
+### Twitter / X (local only)
+
+Twitter sources are only available in local mode. The fetcher reads your browser's session cookies directly — no API key required — but this approach is against X's Terms of Service, so it cannot be used in the cloud pipeline.
+
+**Prerequisites:**
+1. **Log in to X in Chrome** on the same machine. The fetcher reads `auth_token` and `ct0` cookies from your Chrome profile automatically via [`rookiepy`](https://github.com/thewh1teagle/rookiepy).
+2. **Install the `llm` extras** (includes `rookiepy`):
+   ```bash
+   uv sync --extra llm
+   ```
+3. **Verify the cookie setup:**
+   ```bash
+   uv run ainews twitter-setup
+   ```
+4. **Add Twitter sources** to `config/sources.yml` with `type: twitter` and `handle: username`.
+
+> **Why not in the cloud?** The method relies on scraping private GraphQL endpoints using your personal session cookies, which violates [X's Terms of Service](https://x.com/en/tos). Running it in a public CI pipeline would also expose your personal session. Use RSS-based alternatives (e.g. [nitter](https://github.com/zedeus/nitter) via RSSHub) for the cloud pipeline if you need Twitter content.
+
+## 2. Online Public (Vercel + GitHub Actions)
+
+Static read-only dashboard. GitHub Action fetches pre-defined feeds on a 2h cron, exports to `static/data.json`, and Vercel serves it. Data is kept for approximately one week.
+
+No database, no backend, no Ollama required. Scoring is optional (needs `ANTHROPIC_API_KEY`).
+
+**Setup:**
+1. Connect repo to Vercel (output directory: `static/`)
+2. Optionally add `ANTHROPIC_API_KEY` as a GitHub Actions secret for scoring
+3. Trigger the "Fetch & Export" workflow manually for the first run
+
+## 3. Online Login (Supabase + Vercel)
+
+Authenticated mode where users create accounts, manage their own source list, and fetch feeds on demand. Each user's data is fully isolated via Row Level Security.
+
+New users get a pre-defined source list but **no pre-fetched content** — items appear only after clicking "Fetch" in the admin UI. Sources can be added, edited, disabled, or removed.
+
+**Setup:**
+1. Create a [Supabase](https://supabase.com) project
+2. Run migrations: `supabase link --project-ref <ref>` then `supabase db push` (or paste `supabase/migrations/*.sql` in the SQL Editor)
+3. Set Vercel environment variables: `AINEWS_SUPABASE_URL`, `AINEWS_SUPABASE_KEY`, `AINEWS_SUPABASE_SERVICE_KEY`
+4. Optionally set `AINEWS_CORS_ORIGIN` to restrict cross-origin requests
+
+## Pages
+
+| Page | Local | Vercel | Description |
+|------|-------|--------|-------------|
+| Feeds | `/` | `index.html` | Main feed with filters, search, pagination |
+| Leaderboard | `/leaderboard` | `leaderboard.html` | AI benchmark and ranking sites |
+| Events | `/events` | `events.html` | Event calendars, Luma, tech events (3 tabs) |
+| Trends | `/trends` | `trends.html` | GitHub trending repos — daily + history (2 tabs) |
+| CCC | `/ccc` | `ccc.html` | Claude Code Changelogs |
+| About | `/about` | `about.html` | About page |
+| Admin | `/admin` | `admin.html` | Source management (local); read-only (public); source CRUD + fetch (login) |
+
+## Configuration
+
+All settings are via environment variables prefixed `AINEWS_`. See `src/ainews/config.py` for defaults.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AINEWS_SCORING` | `true` | Set `false` to disable scoring |
+| `AINEWS_OLLAMA_MODEL` | `qwen3:4b` | Ollama model for local scoring |
+| `AINEWS_ADMIN_PASSWORD` | _(empty)_ | When set, admin routes require login |
+| `AINEWS_SUPABASE_URL` | — | Supabase project URL |
+| `AINEWS_SUPABASE_KEY` | — | Supabase anon key |
+| `AINEWS_SUPABASE_SERVICE_KEY` | — | Supabase service role key |
+| `AINEWS_CORS_ORIGIN` | — | Restrict cross-origin requests |
+
+See [development.md](development.md) for additional dev-specific settings.
+
+---
+
+*Last updated: 2026-03-15*


### PR DESCRIPTION
## Summary
- Slim down README from 118 to 48 lines — keeps description, screenshots, quick start, deployment mode summary table, doc links, and support
- Move deployment modes (local/public/login setup), Twitter/X guide, pages table, and env var reference to new `docs/deployment.md`
- Clean up `docs/README.md` to be a concise index of all doc files

## Test plan
- [ ] Verify all links in README resolve correctly
- [ ] Verify `docs/deployment.md` contains the full setup instructions previously in README
- [ ] Verify `docs/README.md` index lists all doc files

🤖 Generated with [Claude Code](https://claude.com/claude-code)