### PR TITLE
Add CodeQL workflow and update security audit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Monday 6am UTC
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,16 +26,19 @@ You can expect an acknowledgement within 48 hours and a resolution timeline with
 | Mode | Network | Auth | Attack Surface |
 |---|---|---|---|
 | Local (`uv run ainews serve`) | LAN (binds `0.0.0.0:8000`) | Optional (`AINEWS_ADMIN_PASSWORD`) | FastAPI + SQLite |
-| Online (Vercel) | Public internet | None (read-only static site) | Static HTML + `data.json` |
+| Online public (Vercel) | Public internet | None (read-only static site) | Static HTML + `data.json` |
+| Online login (Vercel) | Public internet | Supabase Auth (email/password) | Static HTML + PostgREST + serverless |
 
 ### Authentication
 
-- **Admin auth** is optional, enabled by setting `AINEWS_ADMIN_PASSWORD` env var
+- **Local admin auth** is optional, enabled by setting `AINEWS_ADMIN_PASSWORD` env var
 - When enabled, admin routes (`/admin/api/*`) require a session cookie
 - Login: `POST /admin/login` validates password via `secrets.compare_digest()` (constant-time comparison)
 - Session cookie: `httponly=True`, `samesite="strict"`, `max_age=86400` (24 hours)
 - Protected routes use FastAPI `Depends()` dependency injection
 - When `AINEWS_ADMIN_PASSWORD` is unset, admin routes are open (single-user local tool)
+- **Online login auth** uses Supabase Auth (email/password). JWTs validated server-side via Supabase Auth API (`GET /auth/v1/user`), not decoded locally — avoids algorithm confusion attacks
+- Serverless function (`api/fetch_source.py`) extracts `user_id` from verified auth response, not from JWT payload directly
 
 ### Data Access
 
@@ -50,6 +53,10 @@ You can expect an acknowledgement within 48 hours and a resolution timeline with
 |---|---|---|
 | `AINEWS_ADMIN_PASSWORD` | Yes | Admin login password (local mode) |
 | `ANTHROPIC_API_KEY` | Yes | Claude API for cloud scoring |
+| `AINEWS_SUPABASE_SERVICE_KEY` | Yes | Supabase service role key (server-side only) |
+| `AINEWS_SUPABASE_URL` | No | Supabase project URL |
+| `AINEWS_SUPABASE_KEY` | No | Supabase anon/publishable key |
+| `AINEWS_CORS_ORIGIN` | No | Allowed CORS origin for serverless endpoints |
 | `AINEWS_OLLAMA_MODEL` | No | Ollama model name |
 | `AINEWS_DB_PATH` | No | SQLite database path |
 | `AINEWS_SCORING` | No | Enable/disable scoring |
@@ -57,6 +64,8 @@ You can expect an acknowledgement within 48 hours and a resolution timeline with
 - `.env` is in `.gitignore` — never committed
 - GitHub Actions secrets are used for `ANTHROPIC_API_KEY` in CI workflows
 - No secrets are hardcoded in source code
+- Service key (`AINEWS_SUPABASE_SERVICE_KEY`) is server-side only — never exported to `config.json` or static files
+- CORS restricted: headers only sent when `AINEWS_CORS_ORIGIN` is set AND `Origin` matches exactly. No wildcard `*`
 
 ### OWASP Top 10 Mitigations
 
@@ -68,8 +77,9 @@ You can expect an acknowledgement within 48 hours and a resolution timeline with
 | Sensitive Data Exposure | All secrets loaded from env vars, never logged. `.env` is gitignored. Browser cookies (Twitter/Xiaohongshu) stay local, never transmitted to cloud pipeline. |
 | XSS (Server-side) | Jinja2 templates use default auto-escaping — all `{{ variable }}` output is HTML-escaped. No `|safe` filter or `{% autoescape false %}` overrides. |
 | XSS (Client-side) | Static pages use `escapeHtml()` / `esc()` helpers for text content in `innerHTML`. See [Known Issues](#known-issues) for gaps. |
+| SSRF | Serverless endpoint (`api/fetch_source.py`) validates URLs via `_is_safe_url()`: blocks private IPs, resolves DNS before checking, blocks `localhost` and `metadata.google.internal`. Local mode URLs come from admin-controlled `sources.yml`. |
 | Security Misconfiguration | Vercel deployment is static-only (no serverless). No debug mode in production. No overly permissive CORS. |
-| Vulnerable Components | Dependabot monitors dependencies weekly. No application-level CVEs in current deps. |
+| Vulnerable Components | Dependabot monitors dependencies weekly. GitHub CodeQL runs on PRs + weekly schedule. No application-level CVEs in current deps. |
 | YAML Deserialization | Uses `yaml.safe_load()` (stdlib) and `ruamel.yaml.YAML()` (safe by default). No unsafe `yaml.load()`. |
 
 ### Third-Party Services
@@ -84,46 +94,108 @@ You can expect an acknowledgement within 48 hours and a resolution timeline with
 
 ## Known Issues
 
-Issues identified in the security audit of 2026-03-11. Severity is assessed in the context of a single-user local tool.
+Issues identified in security audits. Severity is assessed in the context of a single-user local tool + multi-tenant online mode.
 
-### MEDIUM
+### MEDIUM (open)
+
+**[M4] Unauthenticated `/api/fetch` endpoint**
+
+`POST /api/fetch` triggers a fetch+score cycle without auth. Any device on the local network can trigger it. Impact is limited to resource usage (Ollama inference). Promoted from L3 given the default `0.0.0.0` bind.
+
+**[M5] PostgREST filter injection via search input**
+
+Search input in `supabase_backend.py` (lines 211–214) and `static/index.html` (line 209) escapes `%`, `\`, `,`, `.` but not parentheses, which could theoretically manipulate PostgREST filter grouping. Likely causes errors rather than bypass, but is a defense-in-depth gap. Fix: use per-column `ilike()` filters or allowlist `[a-zA-Z0-9\s]`.
+
+**[M6] Verbose error messages in serverless function**
+
+`api/fetch_source.py` line 325 returns `type(e).__name__: {e}` to the client in 500 responses. Could leak internal paths or library details. Fix: log full error server-side, return generic message to client.
+
+**[M7] XSS via `JSON.stringify` in admin template onclick**
+
+`templates/admin.html` line 167 places `JSON.stringify(s)` in a single-quoted `onclick` attribute. A source name containing `'` could break out. Mitigated: only accessible to authenticated admins. The static `admin.html` uses safe `data-id` event delegation.
+
+**[M8] `.gitignore` only covers `.env`, not `.env.*` variants**
+
+`.env.local`, `.env.production`, etc. are not gitignored and could be accidentally committed. Fix: add `.env*` with `!.envrc` exception.
+
+### MEDIUM (fixed)
 
 **[M1] Stored XSS via unescaped URL in `static/index.html` — FIXED 2026-03-11**
 
-`item.url` was interpolated directly into an `href` attribute without escaping. Fixed by applying `escapeHtml()` to the URL, matching the pattern used in all other static pages.
+`item.url` was interpolated directly into an `href` attribute without escaping. Fixed by applying `escapeHtml()` to the URL.
 
 **[M2] Unescaped `tier`, `tags`, and `source_type` in `static/index.html` — FIXED 2026-03-11**
 
-`item.tier`, tag values, and `typeTag` were interpolated directly into `innerHTML` without escaping. Fixed by applying `escapeHtml()` to all dynamic values in template literals.
+`item.tier`, tag values, and `typeTag` were interpolated directly into `innerHTML` without escaping. Fixed by applying `escapeHtml()`.
 
 **[M3] Tag values in `onclick` handler in `static/index.html` — FIXED 2026-03-11**
 
-Tag names were interpolated into an `onclick` attribute string. `escapeHtml()` does not escape single quotes, so a dedicated `escapeAttr()` helper was added that also encodes `'` to `&#39;`.
+Tag names were interpolated into an `onclick` attribute. Fixed with `escapeAttr()` helper.
 
 ### LOW
 
 **[L1] Static session token derived from password hash**
 
-The admin session cookie value is `SHA256(password)` — deterministic and never rotates. For a single-user local tool this is acceptable, but not suitable for multi-user or production deployments.
+The admin session cookie value is `SHA256(password)` — deterministic and never rotates. Acceptable for single-user local tool.
 
 **[L2] Missing `secure` flag on admin cookie**
 
-The `admin_token` cookie lacks `secure=True`, meaning it could be transmitted over HTTP. Acceptable for local-only mode (`http://localhost:8000`), but should be added if HTTPS is ever used.
-
-**[L3] Unauthenticated `/api/fetch` endpoint**
-
-`POST /api/fetch` triggers a fetch+score cycle without auth. Any device on the local network can trigger it. Impact is limited to resource usage (Ollama inference).
+The `admin_token` cookie lacks `secure=True`. Acceptable for local-only mode (`http://localhost:8000`).
 
 **[L4] No input bounds on `page` and `since_hours` query parameters**
 
-`page` accepts zero/negative values and `since_hours` has no upper bound. Impact is limited to unexpected query results, not a security breach.
+`page` accepts zero/negative values and `since_hours` has no upper bound. Impact is limited to unexpected query results.
+
+**[L5] No brute-force protection on admin login**
+
+`POST /admin/login` has no rate limiting or lockout. Local-only feature; online mode uses Supabase Auth.
+
+**[L6] Default bind to `0.0.0.0`**
+
+`config.py` line 24 binds to all interfaces by default, exposing the server to the local network. Consider defaulting to `127.0.0.1`.
+
+**[L7] GitHub Actions use tag refs, not SHA pins**
+
+All 15 action references across 6 workflows use mutable tags (`@v6`, `@v3`). Dependabot for github-actions mitigates this somewhat. Full SHA pinning recommended for supply-chain hardening.
+
+**[L8] `actions/checkout@v4` in `migrations.yml` vs `@v6` everywhere else**
+
+Version inconsistency across workflows. Should align to v6.
+
+### INFO (positive findings)
+
+- All SQLite queries use parameterized statements — no SQL injection
+- Supabase backend consistently scopes all queries by `user_id`
+- RLS enabled on all tables with full CRUD policies using `auth.uid() = user_id`
+- JWT validation via server-side Supabase Auth API (not local decode)
+- `secrets.compare_digest()` for constant-time password comparison
+- SSRF protection in serverless endpoint (`_is_safe_url()`)
+- No `os.system()`, `subprocess.run(shell=True)`, `exec()`, or `eval()` in codebase
+- No `|safe` filter or `{% autoescape false %}` in Jinja2 templates
+- Static pages use `escapeHtml()` / `esc()` consistently
+- YAML loading is safe: `yaml.safe_load()` + `ruamel.yaml.YAML()` (safe by default)
+- Service key never appears in client-side code or static files
+- `.env` never committed to git history
+- No CVEs in any runtime Python dependency (as of 2026-03-15)
 
 ## Audit History
 
 | Date | Scope | Findings | Auditor |
 |---|---|---|---|
+| 2026-03-15 | Full codebase (secrets, deps, OWASP, auth, config) | 0 critical, 0 high, 5 medium (open), 3 medium (fixed), 8 low | Claude Opus 4.6 |
 | 2026-03-11 | Full codebase | 0 critical, 0 high, 3 medium (all fixed), 4 low | Claude Opus 4.6 |
+
+## Automated Security
+
+| Tool | Scope | Frequency | Status |
+|---|---|---|---|
+| Dependabot alerts | Known CVEs in Python deps | Continuous | Enabled 2026-03-15 |
+| Dependabot security updates | Auto-PR for vulnerable deps | On CVE detection | Enabled 2026-03-15 |
+| Dependabot version updates | Weekly dep bumps | Weekly | Configured (pip + github-actions) |
+| Secret scanning | Committed secrets detection | On push | Enabled 2026-03-15 |
+| Push protection | Block pushes with secrets | On push | Enabled 2026-03-15 |
+| CodeQL | Static analysis (injection, XSS, etc.) | On PR + weekly | Pending setup |
 
 ---
 
-*Last updated: 2026-03-11*
+*Last updated: 2026-03-15*


### PR DESCRIPTION
## Summary
- Add `.github/workflows/codeql.yml` — automated static analysis on PRs + weekly schedule
- Update `SECURITY.md` with full 2026-03-15 audit results:
  - Online login mode threat model and auth documentation
  - 5 new medium findings (open), 8 low findings documented
  - Automated security tracking table (Dependabot, secret scanning, CodeQL)
  - SSRF protection documentation
  - Expanded environment variables table

## Context
Ran a full security audit (secrets, deps, OWASP, auth/access-control) with 4 parallel agents.
Also enabled Dependabot alerts, security updates, secret scanning, and push protection via GitHub API.

## Test plan
- [ ] CodeQL workflow runs successfully on this PR
- [ ] SECURITY.md renders correctly on GitHub
- [x] Dependabot alerts appear in Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)