### PR TITLE
Make feed cards clickable with hover/active highlight

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -370,7 +370,8 @@
     document.getElementById('items').addEventListener('click', function(e) {
         var card = e.target.closest('[data-url]');
         if (!card || e.target.closest('a')) return;
-        window.open(card.dataset.url, '_blank');
+        var url = card.dataset.url;
+        if (url && /^https?:\/\//.test(url)) window.open(url, '_blank');
     });
     function escapeHtml(text) { const div = document.createElement('div'); div.textContent = text || ''; return div.innerHTML; }
     function escapeAttr(text) { return escapeHtml(text).replace(/'/g, '&#39;'); }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -166,6 +166,6 @@
 {% endif %}
 <script>
 document.addEventListener('click', function() { var dd = document.getElementById('tag-dropdown'); if (dd) dd.classList.add('hidden'); });
-document.addEventListener('click', function(e) { var card = e.target.closest('[data-url]'); if (!card || e.target.closest('a')) return; window.open(card.dataset.url, '_blank'); });
+document.addEventListener('click', function(e) { var card = e.target.closest('[data-url]'); if (!card || e.target.closest('a')) return; var url = card.dataset.url; if (url && /^https?:\/\//.test(url)) window.open(url, '_blank'); });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Make entire feed card clickable (opens link in new tab), not just the title text
- Add hover background highlight (`hover:bg-gray-50` / `hover:bg-neutral-800`)
- Add active press state (`active:bg-gray-100` / `active:bg-neutral-700`) with subtle scale feedback
- New-item cards use blue-toned hover/active states to stay consistent
- Uses `data-url` attribute + event delegation (not inline `onclick`) to prevent XSS
- Clicking the title `<a>` link still works independently (handler skips `<a>` clicks)
- Guard against `javascript:` and other non-HTTP URL schemes in `window.open()` calls

## Test plan
- [ ] Click anywhere on a feed card — should open the link in a new tab
- [ ] Click the title link directly — should also work (no double-open)
- [ ] Hover over a card — background should subtly change
- [ ] Press down on a card — should show active state
- [ ] Test in both light and dark mode
- [ ] Test both localhost and static versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)