### PR TITLE
Fix per-category badge counts on feed filter tabs

### DIFF
--- a/src/ainews/api/app.py
+++ b/src/ainews/api/app.py
@@ -307,7 +307,10 @@ def dashboard(
             "total_new": total_new,
         },
     )
-    _set_last_seen(response, "dashboard")
+    # Only update last-seen when viewing the unfiltered feed so that
+    # per-category badge counts survive tab clicks and pagination.
+    if not any([source_type, tier, tag, min_score, search]) and page == 1:
+        _set_last_seen(response, "dashboard")
     return response
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -244,15 +244,34 @@
     const activeCls = 'bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-400 border-blue-300 dark:border-blue-700';
     const inactiveCls = 'bg-white dark:bg-neutral-800 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-neutral-700 hover:border-gray-300 dark:hover:border-neutral-600';
 
+    function badgeHtml(count) {
+        if (!count) return '';
+        var text = count > 99 ? '99+' : count;
+        return ` <span class="ml-1 bg-blue-500 text-white text-[10px] rounded-full px-1 min-w-[14px] text-center leading-4 font-bold">${text}</span>`;
+    }
+
     function buildFilters() {
+        // Count new items per normalized source type
+        var newCounts = {};
+        var totalNew = 0;
+        allItems.forEach(function(item) {
+            if (!window.isNewItem || !window.isNewItem(item)) return;
+            if (HIDDEN_TYPES.includes(item.source_type) || HIDDEN_SOURCES.includes(item.source_name)) return;
+            var t = TYPE_NORMALIZE[item.source_type] || item.source_type;
+            newCounts[t] = (newCounts[t] || 0) + 1;
+            totalNew++;
+        });
+
         const types = (isSupabaseMode ? allSourceTypes : [...new Set(allItems.map(i => i.source_type))]).filter(t => !HIDDEN_TYPES.includes(t)).sort();
-        let html = `<button class="px-3 py-1.5 rounded-md text-sm border cursor-pointer ${activeCls}" onclick="setFilter({})">All</button>`;
+        var noFilter = !filters.source_type && !filters.tag && filters.order_by === 'date';
+        let html = `<button class="px-3 py-1.5 rounded-md text-sm border cursor-pointer ${noFilter ? activeCls : inactiveCls}" onclick="setFilter({})">All${badgeHtml(totalNew)}</button>`;
         types.forEach(t => {
             const label = TYPE_LABELS[t] || t.charAt(0).toUpperCase() + t.slice(1);
-            html += `<button class="px-3 py-1.5 rounded-md text-sm border cursor-pointer ${inactiveCls}" onclick="setFilter({source_type:'${escapeAttr(t)}'})">${escapeHtml(label)}</button>`;
+            var cls = filters.source_type === t ? activeCls : inactiveCls;
+            html += `<button class="px-3 py-1.5 rounded-md text-sm border cursor-pointer ${cls}" onclick="setFilter({source_type:'${escapeAttr(t)}'})">${escapeHtml(label)}${badgeHtml(newCounts[t])}</button>`;
         });
         // Feature flag: AINEWS_SHOW_SCORES — do not delete, enable via config
-        if (showScores) html += `<button class="px-3 py-1.5 rounded-md text-sm border cursor-pointer ${inactiveCls}" onclick="setFilter({order_by:'score'})">By Score</button>`;
+        if (showScores) html += `<button class="px-3 py-1.5 rounded-md text-sm border cursor-pointer ${filters.order_by === 'score' ? activeCls : inactiveCls}" onclick="setFilter({order_by:'score'})">By Score</button>`;
         if (allTags.length) {
             html += `<div class="relative inline-block"><button class="px-3 py-1.5 rounded-md text-sm border cursor-pointer ${inactiveCls}" onclick="toggleTagDropdown(event)">Tags</button><div class="hidden absolute top-full left-0 mt-1 bg-white dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 rounded-md min-w-40 max-h-72 overflow-y-auto z-10 shadow-lg" id="tag-dropdown">`;
             allTags.forEach(t => { html += `<a class="block px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-700 cursor-pointer" onclick="setFilter({tag:'${escapeAttr(t)}'})">${escapeHtml(t)}</a>`; });
@@ -264,6 +283,7 @@
     function setFilter(f) {
         filters = { source_type: null, tier: null, tag: null, order_by: 'date', ...f };
         page = 1;
+        buildFilters();
         if (isSupabaseMode) { loadSupabaseItems(); } else { render(); }
     }
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -450,6 +450,108 @@ class TestMode1Local:
         assert "bg-blue-50/70" in resp.text  # blue highlight background
         assert "New</span>" in resp.text  # "New" pill
 
+    def test_dashboard_badge_counts_per_category(self, config_dir, tmp_path, monkeypatch):
+        """Per-category badge counts show on filter tabs for returning visitors."""
+        import importlib
+        import shutil
+        from datetime import datetime, timedelta
+
+        import ainews.api.admin
+        import ainews.api.app
+        import ainews.config
+
+        monkeypatch.setenv("AINEWS_CONFIG_DIR", str(config_dir))
+        monkeypatch.setenv("AINEWS_DB_PATH", str(tmp_path / "test.db"))
+        monkeypatch.setenv("AINEWS_SCORING", "false")
+        monkeypatch.delenv("AINEWS_SUPABASE_URL", raising=False)
+        monkeypatch.delenv("AINEWS_SUPABASE_KEY", raising=False)
+        (config_dir.parent / "static").mkdir(exist_ok=True)
+        real_templates = Path(__file__).resolve().parent.parent / "templates"
+        if not (config_dir.parent / "templates").exists():
+            shutil.copytree(real_templates, config_dir.parent / "templates")
+
+        importlib.reload(ainews.config)
+        importlib.reload(ainews.api.admin)
+        importlib.reload(ainews.api.app)
+
+        from ainews.storage.db import SqliteBackend
+
+        backend = SqliteBackend(tmp_path / "test.db")
+        backend.upsert_item(_make_item("https://t.co/1", "Tweet 1", source_type="twitter"))
+        backend.upsert_item(_make_item("https://t.co/2", "Tweet 2", source_type="twitter"))
+        backend.upsert_item(_make_item("https://yt.com/1", "Video 1", source_type="youtube"))
+        backend.upsert_item(_make_item("https://rss.com/1", "RSS Post", source_type="rss"))
+        backend.commit()
+        backend.close()
+
+        client = TestClient(ainews.api.app.app, raise_server_exceptions=False)
+
+        past = (datetime.now() - timedelta(hours=2)).isoformat()
+        resp = client.get("/", cookies={"ainews_last_seen_dashboard": past})
+        assert resp.status_code == 200
+
+        # "All" badge should show total (4)
+        # Per-category badges: Twitter=2, YouTube=1, RSS=1
+        import re
+
+        badges = re.findall(
+            r'>(\w[\w ]*?)(<span class="ml-1 bg-blue-500.*?">(\d+)</span>)',
+            resp.text,
+        )
+        badge_map = {label.strip(): int(count) for label, _, count in badges}
+        assert badge_map.get("All") == 4
+        assert badge_map.get("Twitter") == 2
+        assert badge_map.get("YouTube") == 1
+        assert badge_map.get("RSS") == 1
+
+    def test_dashboard_cookie_not_reset_on_filtered_view(self, config_dir, tmp_path, monkeypatch):
+        """Clicking a category tab should not reset the last-seen cookie."""
+        import importlib
+        import shutil
+        from datetime import datetime, timedelta
+
+        import ainews.api.admin
+        import ainews.api.app
+        import ainews.config
+
+        monkeypatch.setenv("AINEWS_CONFIG_DIR", str(config_dir))
+        monkeypatch.setenv("AINEWS_DB_PATH", str(tmp_path / "test.db"))
+        monkeypatch.setenv("AINEWS_SCORING", "false")
+        monkeypatch.delenv("AINEWS_SUPABASE_URL", raising=False)
+        monkeypatch.delenv("AINEWS_SUPABASE_KEY", raising=False)
+        (config_dir.parent / "static").mkdir(exist_ok=True)
+        real_templates = Path(__file__).resolve().parent.parent / "templates"
+        if not (config_dir.parent / "templates").exists():
+            shutil.copytree(real_templates, config_dir.parent / "templates")
+
+        importlib.reload(ainews.config)
+        importlib.reload(ainews.api.admin)
+        importlib.reload(ainews.api.app)
+
+        from ainews.storage.db import SqliteBackend
+
+        backend = SqliteBackend(tmp_path / "test.db")
+        backend.upsert_item(_make_item("https://t.co/1", "Tweet", source_type="twitter"))
+        backend.commit()
+        backend.close()
+
+        client = TestClient(ainews.api.app.app, raise_server_exceptions=False)
+
+        past = (datetime.now() - timedelta(hours=2)).isoformat()
+
+        # Filtered view (source_type=twitter) should NOT update the cookie
+        resp = client.get(
+            "/?source_type=twitter",
+            cookies={"ainews_last_seen_dashboard": past},
+        )
+        assert resp.status_code == 200
+        assert "ainews_last_seen_dashboard" not in resp.cookies
+
+        # Unfiltered "All" page 1 SHOULD update the cookie
+        resp2 = client.get("/", cookies={"ainews_last_seen_dashboard": past})
+        assert resp2.status_code == 200
+        assert "ainews_last_seen_dashboard" in resp2.cookies
+
 
 # ============================================================
 # Mode 2: Online Public — cloud_fetch + export + static JSON


### PR DESCRIPTION
## Summary
- **Local mode**: Only reset the `last_seen` cookie on unfiltered "All" page (page 1, no filters). Previously every page load reset the cookie, so clicking a category tab immediately wiped all badge counts.
- **Static/online mode**: `buildFilters()` now computes per-source-type new-item counts using `isNewItem()` from badges.js and renders badge pills on each filter button.
- **Bonus**: Filter tab active state highlighting now works correctly in static mode (was always showing "All" as active).

## Test plan
- [x] Two new unit tests in `test_e2e.py`:
  - `test_dashboard_badge_counts_per_category` — verifies badge counts (All=4, Twitter=2, YouTube=1, RSS=1) appear in response HTML
  - `test_dashboard_cookie_not_reset_on_filtered_view` — verifies cookie is NOT set on filtered views, IS set on unfiltered "All"
- [ ] Manual: visit local dashboard, verify badges show on category tabs after fetching new items
- [ ] Manual: click a category tab, verify badges persist (don't disappear)
- [ ] Manual: verify static site filter buttons show badge counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)