### PR TITLE
Add favicon and Vercel Analytics

### DIFF
--- a/static/about.html
+++ b/static/about.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About — MyFocalAI</title>
+    <link rel="icon" href="logo.svg" type="image/svg+xml">
     <script>
     (function(){
         var t = localStorage.getItem('theme');
@@ -18,6 +19,7 @@
     <style type="text/tailwindcss">
     @custom-variant dark (&:where(.dark, .dark *));
     </style>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 dark:bg-neutral-950 dark:text-gray-200 antialiased">
     <nav id="main-nav" data-active="about" class="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 sticky top-0 z-50"></nav>

--- a/static/admin.html
+++ b/static/admin.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Admin — MyFocalAI</title>
+    <link rel="icon" href="logo.svg" type="image/svg+xml">
     <script>
     (function(){
         var t = localStorage.getItem('theme');
@@ -18,6 +19,7 @@
     <style type="text/tailwindcss">
     @custom-variant dark (&:where(.dark, .dark *));
     </style>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 dark:bg-neutral-950 dark:text-gray-200 antialiased">
     <nav id="main-nav" data-active="admin" class="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 sticky top-0 z-50"></nav>

--- a/static/ccc.html
+++ b/static/ccc.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CCC — Claude Code Changelogs</title>
+    <link rel="icon" href="logo.svg" type="image/svg+xml">
     <script>
     (function(){
         var t = localStorage.getItem('theme');
@@ -18,6 +19,7 @@
     <style type="text/tailwindcss">
     @custom-variant dark (&:where(.dark, .dark *));
     </style>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 dark:bg-neutral-950 dark:text-gray-200 antialiased">
     <nav id="main-nav" data-active="ccc" class="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 sticky top-0 z-50"></nav>

--- a/static/events.html
+++ b/static/events.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Events — MyFocalAI</title>
+    <link rel="icon" href="logo.svg" type="image/svg+xml">
     <script>
     (function(){
         var t = localStorage.getItem('theme');
@@ -18,6 +19,7 @@
     <style type="text/tailwindcss">
     @custom-variant dark (&:where(.dark, .dark *));
     </style>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 dark:bg-neutral-950 dark:text-gray-200 antialiased">
     <nav id="main-nav" data-active="events" class="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 sticky top-0 z-50"></nav>

--- a/static/index.html
+++ b/static/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MyFocalAI</title>
+    <link rel="icon" href="logo.svg" type="image/svg+xml">
     <script>
     (function(){
         var t = localStorage.getItem('theme');
@@ -22,6 +23,7 @@
     .animate-fadeIn { animation: fadeIn 0.3s ease-out; }
     .animate-slideUp { animation: slideUp 0.4s ease-out; }
     </style>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 dark:bg-neutral-950 dark:text-gray-200 antialiased">
     <nav id="main-nav" data-active="dashboard" class="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 sticky top-0 z-50"></nav>

--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Leaderboard — MyFocalAI</title>
+    <link rel="icon" href="logo.svg" type="image/svg+xml">
     <script>
     (function(){
         var t = localStorage.getItem('theme');
@@ -18,6 +19,7 @@
     <style type="text/tailwindcss">
     @custom-variant dark (&:where(.dark, .dark *));
     </style>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 dark:bg-neutral-950 dark:text-gray-200 antialiased">
     <nav id="main-nav" data-active="leaderboard" class="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 sticky top-0 z-50"></nav>

--- a/static/trends.html
+++ b/static/trends.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Trends — GitHub Trending</title>
+    <link rel="icon" href="logo.svg" type="image/svg+xml">
     <script>
     (function(){
         var t = localStorage.getItem('theme');
@@ -18,6 +19,7 @@
     <style type="text/tailwindcss">
     @custom-variant dark (&:where(.dark, .dark *));
     </style>
+    <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="bg-gray-50 text-gray-900 dark:bg-neutral-950 dark:text-gray-200 antialiased">
     <nav id="main-nav" data-active="trends" class="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 sticky top-0 z-50"></nav>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ page_title | default('MyFocalAI') }}</title>
+    <link rel="icon" href="/static/logo.svg" type="image/svg+xml">
     <script>
     (function(){
         var t = localStorage.getItem('theme');


### PR DESCRIPTION
## Summary
- Add `logo.svg` as the site favicon across all 7 static pages and the localhost base template
- Add Vercel Analytics (`/_vercel/insights/script.js`) to all static pages for visitor and page view tracking

## Test plan
- [ ] Verify favicon appears in browser tab on myfocalai.vercel.app
- [ ] Verify favicon appears when running locally (`uv run ainews serve`)
- [ ] Verify Vercel Analytics dashboard shows page views after deployment
- [ ] Check no JS console errors from the analytics script

🤖 Generated with [Claude Code](https://claude.com/claude-code)