### PR TITLE
Fix 7 CodeQL security alerts (SSRF, weak hashing, URL sanitization)

### DIFF
--- a/api/fetch_source.py
+++ b/api/fetch_source.py
@@ -196,6 +196,8 @@ def _fetch_and_ingest(base_url, service_key, user_id, source_type, name, config,
         return 0, 0
 
     url = feed_meta["url"]
+    if not url.startswith(("http://", "https://")):
+        raise ValueError("Only HTTP(S) URLs are allowed")
     if not _is_safe_url(url):
         raise ValueError("Blocked URL: not allowed to fetch internal/private addresses")
     headers = {"User-Agent": "Mozilla/5.0 (compatible; ainews/0.1)"}

--- a/api/resolve_url.py
+++ b/api/resolve_url.py
@@ -129,6 +129,9 @@ def _resolve_youtube(url: str, parsed) -> dict:
         author_url = data.get("author_url", "")
         if not author_url:
             raise ValueError("Could not determine channel from video")
+        author_host = urlparse(author_url).hostname or ""
+        if author_host not in YOUTUBE_HOSTS:
+            raise ValueError("Unexpected author URL from oEmbed")
         channel_id, _ = _fetch_yt_page_info(author_url)
         return _result("youtube", {"channel_id": channel_id, "name": author_name})
 
@@ -136,6 +139,8 @@ def _resolve_youtube(url: str, parsed) -> dict:
 
 
 def _fetch_yt_page_info(page_url: str) -> tuple:
+    if not _is_safe_url(page_url):
+        raise ValueError("Blocked URL: not allowed to fetch internal/private addresses")
     headers = {"User-Agent": BROWSER_UA, "Cookie": "CONSENT=YES+1"}
     resp = httpx.get(page_url, headers=headers, timeout=15, follow_redirects=True)
     if resp.status_code != 200:

--- a/src/ainews/api/admin.py
+++ b/src/ainews/api/admin.py
@@ -1,8 +1,8 @@
 """Admin UI for source management."""
 
-import hashlib
 import logging
 import secrets
+import time
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
 settings = Settings()
 templates = Jinja2Templates(directory=str(settings.config_dir.parent / "templates"))
 
-_password_hash = (
-    hashlib.sha256(settings.admin_password.encode()).hexdigest() if settings.admin_password else ""
-)
+# Random session tokens with creation time for TTL enforcement
+_SESSION_TTL = 86400  # 24 hours, matches cookie max_age
+_active_sessions: dict[str, float] = {}
 
 
 def _check_admin_auth(admin_token: str | None) -> None:
@@ -36,7 +36,18 @@ def _check_admin_auth(admin_token: str | None) -> None:
         return
     if not admin_token:
         raise HTTPException(status_code=401, detail="Login required")
-    if not secrets.compare_digest(admin_token, _password_hash):
+    now = time.monotonic()
+    # Iterate all tokens without short-circuit to preserve constant-time behavior
+    valid = False
+    expired = []
+    for token, created_at in _active_sessions.items():
+        if now - created_at > _SESSION_TTL:
+            expired.append(token)
+        elif secrets.compare_digest(admin_token, token):
+            valid = True
+    for token in expired:
+        del _active_sessions[token]
+    if not valid:
         raise HTTPException(status_code=401, detail="Invalid session")
 
 
@@ -69,14 +80,16 @@ def admin_login(body: dict, response: Response):
     password = body.get("password", "")
     if not secrets.compare_digest(password, settings.admin_password):
         raise HTTPException(status_code=401, detail="Wrong password")
-    response.set_cookie(
-        "admin_token", _password_hash, httponly=True, samesite="strict", max_age=86400
-    )
+    token = secrets.token_hex(32)
+    _active_sessions[token] = time.monotonic()
+    response.set_cookie("admin_token", token, httponly=True, samesite="strict", max_age=86400)
     return {"status": "ok"}
 
 
 @router.post("/logout")
-def admin_logout(response: Response):
+def admin_logout(response: Response, admin_token: str | None = Cookie(None)):
+    if admin_token:
+        _active_sessions.pop(admin_token, None)
     response.delete_cookie("admin_token")
     return {"status": "ok"}
 

--- a/src/ainews/ingest/github_trending.py
+++ b/src/ainews/ingest/github_trending.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 import httpx
 from selectolax.parser import HTMLParser
@@ -151,7 +152,7 @@ async def fetch_github_trending_history(
         github_link = None
         for a in card.css("a"):
             href = a.attributes.get("href", "")
-            if "github.com" in href:
+            if urlparse(href).hostname in ("github.com", "www.github.com"):
                 github_link = href
                 break
 

--- a/src/ainews/sources/url_resolver.py
+++ b/src/ainews/sources/url_resolver.py
@@ -144,11 +144,13 @@ async def _resolve_youtube_video(url: str) -> ResolvedSource:
         author_name = data.get("author_name", "")
         author_url = data.get("author_url", "")
 
-        # Fetch the channel page to get channel_id
-        if author_url:
-            channel_id, _ = await _fetch_youtube_page_info(author_url, client=client)
-        else:
+        # Validate author_url points to YouTube before following it
+        if not author_url:
             raise ValueError("Could not determine channel from video")
+        author_host = urlparse(author_url).hostname or ""
+        if author_host not in YOUTUBE_HOSTS:
+            raise ValueError("Unexpected author URL from oEmbed")
+        channel_id, _ = await _fetch_youtube_page_info(author_url, client=client)
 
     return ResolvedSource(
         source_type="youtube",
@@ -160,6 +162,8 @@ async def _fetch_youtube_page_info(
     page_url: str, *, client: httpx.AsyncClient | None = None
 ) -> tuple[str, str]:
     """Fetch a YouTube page and extract channel_id and name."""
+    if not _is_safe_url(page_url):
+        raise ValueError("Blocked URL: not allowed to fetch internal/private addresses")
     headers = {"User-Agent": BROWSER_UA, "Cookie": "CONSENT=YES+1"}
 
     async def _fetch(c: httpx.AsyncClient) -> tuple[str, str]:


### PR DESCRIPTION
## Summary

Fixes all 7 CodeQL security alerts detected on main:

- **Alerts #3-7 (Critical) — SSRF**: Added `_is_safe_url()` guard to YouTube page fetches, validated oEmbed `author_url` against `YOUTUBE_HOSTS` allowlist before following, added HTTP(S) scheme check in `fetch_source.py`
- **Alert #2 (High) — Weak crypto**: Replaced deterministic `SHA-256(password)` session token with random `secrets.token_hex(32)`. Added server-side TTL (24h) and constant-time auth check that doesn't short-circuit
- **Alert #1 (High) — URL substring sanitization**: Changed `"github.com" in href` to `urlparse(href).hostname` check to prevent bypass via URLs like `evil.com/github.com/`

## Test plan

- [ ] Verify existing tests pass (`uv run pytest`)
- [ ] Verify admin login/logout still works locally
- [ ] Confirm CodeQL alerts resolve after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)