### PR TITLE
Skip Vercel deploys for non-deployed file changes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "buildCommand": "",
   "framework": null,
   "cleanUrls": true,
+  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD -- static/ api/ vercel.json",
   "functions": {
     "api/*.py": {
       "maxDuration": 10,


### PR DESCRIPTION
## Summary
- Add `ignoreCommand` to `vercel.json` that skips deployment when only non-deployed files change
- Compares against `VERCEL_GIT_PREVIOUS_SHA` (last deployed SHA) to catch all changes since last deploy
- Falls back to `HEAD^` on first-ever deploy
- Only `static/`, `api/`, and `vercel.json` changes trigger a new deployment

This avoids unnecessary deploys for docs, tests, src/, config, and CI workflow changes.

## Test plan
- [ ] Push a docs-only commit → verify Vercel skips deployment
- [ ] Push a `static/` change → verify Vercel deploys normally
- [ ] Verify first deploy on a new Vercel project still works (fallback to `HEAD^`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)