### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.6.0 — 2026-03-16
+
+### Features
+
+- **URL map auto-sync** — RSSHub route map and Olshansk feed map auto-generated from upstream sources, with weekly sync workflow (#160)
+- **Favicon and Vercel Analytics** — Added favicon and analytics tracking to all static pages (#152)
+
+### Fixes
+
+- **CodeQL security alerts** — Fixed 7 alerts: SSRF protection on URL resolution, constant-time session tokens replacing weak SHA-256 hashing, YouTube oEmbed URL validation (#161)
+- **Export-static workflow** — Stage both data.json and config.json to prevent unstaged changes blocking git rebase (#164)
+- **Stale JWT empty feed** — Fix page navigation causing empty feed due to expired JWT (#153)
+
+### Infrastructure
+
+- **Skip irrelevant Vercel deploys** — `ignoreCommand` skips deployment when only non-deployed files change (#163)
+- **Docs consolidation** — Single source of truth for deployment, secrets, module map; removed duplication across 4 files (#162)
+- **Dependency bumps** — actions/checkout v6, upload-artifact v7, setup-node v6 (#157, #158, #159)
+
 ## v0.5.0 — 2026-03-15
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "my-focal-ai"
-version = "0.5.0"
+version = "0.6.0"
 description = "Personal news intelligence system with principle-based filtering"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

Release v0.6.0 — URL map auto-sync, security fixes, and infrastructure improvements.

### Features
- **URL map auto-sync** — RSSHub + Olshansk feed maps auto-generated with weekly sync workflow (#160)
- **Favicon and Vercel Analytics** — Added to all static pages (#152)

### Fixes
- **7 CodeQL security alerts** — SSRF protection, constant-time session tokens, YouTube oEmbed validation (#161)
- **Export-static workflow** — Stage both generated files to prevent rebase failure (#164)
- **Stale JWT empty feed** — Fix expired JWT causing empty feed on navigation (#153)
- **XHS card overflow** — Strip HTML tags from summaries, add overflow-hidden + break-words to all card templates

### Infrastructure
- **Skip irrelevant Vercel deploys** — `ignoreCommand` based on deployed file changes (#163)
- **Docs consolidation** — Single source of truth, removed duplication (#162)
- **Dependency bumps** — actions/checkout v6, upload-artifact v7, setup-node v6 (#157–#159)

## Test plan
- [x] `uv run ruff check src/` — clean
- [x] `uv run pytest` — 205 passed (3 pre-existing async failures, pass in CI)
- [x] Verify CHANGELOG.md entries match merged PRs
- [x] Verify version bump in pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)