### PR TITLE
Add hybrid local-fetch-push for Twitter in online mode

### DIFF
--- a/scripts/local-push.sh
+++ b/scripts/local-push.sh
@@ -28,7 +28,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --hours) HOURS="${2:-168}"; shift 2 ;;
         --all)   FETCH_ALL=true; shift ;;
-        *)       shift ;;
+        *)       echo "Unknown flag: $1"; exit 1 ;;
     esac
 done
 

--- a/src/ainews/export.py
+++ b/src/ainews/export.py
@@ -11,6 +11,16 @@ from ainews.storage.db import get_backend
 logger = logging.getLogger(__name__)
 
 
+def _parse_iso(value: str) -> datetime | None:
+    """Parse an ISO 8601 datetime string, returning None on failure."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
 def _load_existing_items(path: Path, since: datetime) -> list[dict]:
     """Load items from an existing data.json, filtering to the time window."""
     if not path.exists():
@@ -19,13 +29,12 @@ def _load_existing_items(path: Path, since: datetime) -> list[dict]:
         with open(path) as f:
             data = json.load(f)
         items = data.get("items", [])
-        # Keep only items within the export window
-        cutoff = since.isoformat()
-        return [
-            item
-            for item in items
-            if (item.get("published_at") or item.get("fetched_at", "")) >= cutoff
-        ]
+        result = []
+        for item in items:
+            dt = _parse_iso(item.get("published_at") or item.get("fetched_at", ""))
+            if dt and dt >= since:
+                result.append(item)
+        return result
     except (json.JSONDecodeError, KeyError):
         logger.warning("Could not read existing %s, skipping merge", path)
         return []
@@ -67,7 +76,6 @@ def export_items(
                 existing_ids.add(item.id)
 
     all_tags = backend.get_all_tags()
-    total = backend.count_items(since=since, min_score=min_score)
     backend.close()
 
     # Merge: preserve items from existing data.json that aren't in the local DB.
@@ -90,7 +98,7 @@ def export_items(
     data = {
         "exported_at": datetime.now(timezone.utc).isoformat(),
         "period_hours": hours,
-        "total": total,
+        "total": len(serialized_items),
         "all_tags": all_tags,
         "items": serialized_items,
     }


### PR DESCRIPTION
## Summary

- **Export merge**: `export.py` preserves cloud-fetched items in `data.json` during local export, so RSS/YouTube items from GitHub Actions aren't lost when local-push overwrites the file
- **Twitter-only default**: `local-push.sh` fetches only Twitter by default (`--all` for full fetch), since cloud pipeline handles RSS/YouTube/arXiv
- **Source type ordering**: Dashboard badges sort in fixed order (twitter, youtube, rss, arxiv, xiaohongshu) instead of alphabetically
- **XHS card overflow fix**: Strip HTML tags from summaries before display — XHS content had raw `<img>` tags with long URLs overflowing cards
- **Architecture docs**: Added Data Model section and per-mode data flow diagrams

## Test plan
- [x] `uv run pytest` — 205 passed (3 pre-existing e2e failures unrelated)
- [x] `ruff check` + `ruff format` — clean
- [ ] Manual: verify XHS cards no longer overflow
- [ ] Manual: run `./scripts/local-push.sh` and verify only Twitter sources are fetched
- [ ] Manual: verify `data.json` retains cloud items after local export

🤖 Generated with [Claude Code](https://claude.com/claude-code)