### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.7.1 — 2026-03-21
+
+### Fixes
+
+- **Mobile badge counts** — Badge notification counts now display on mobile nav (previously only desktop elements were updated) (#180)
+- **local-push.sh resilience** — Stash unstaged changes before `git pull --rebase` so dirty working trees no longer block the script (#180)
+- **local-push.sh credentials** — Ensure HTTPS remote uses YanCheng-go account for pushes (#180)
+
+### Infrastructure
+
+- **Trends badge disabled** — Badge count for trends page removed (was always noisy) (#179)
+- **New sources** — Added new Twitter and RSS sources (#179)
+- **Feed timeout** — Increased feed fetch timeout (#179)
+- Mobile badge tests added to `run_badges_test.mjs`
+
 ## v0.7.0 — 2026-03-18
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "my-focal-ai"
-version = "0.7.0"
+version = "0.7.1"
 description = "Personal news intelligence system with principle-based filtering"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Bump version to 0.7.1
- Changelog for v0.7.1: mobile badge fix, local-push.sh hardening, trends badge disabled, new sources

### Changes since v0.7.0
- **#180** — Fix mobile badge counts and harden local-push.sh
- **#179** — Disable trends badge, add sources, increase feed timeout

## Test plan
- [x] All tests pass (214 Python, 16 badge)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)