### PR TITLE
Fix card-level badge count and highlighting in online mode

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -421,14 +421,19 @@
                 const rawSummary = (item.summary || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
                 const summary = rawSummary ? rawSummary.slice(0, 200) + (rawSummary.length > 200 ? '...' : '') : '';
                 const borderCls = SOURCE_BORDERS[item.source_type] || 'border-l-gray-300 dark:border-l-neutral-600';
+                const isNew = window.isNewItem && window.isNewItem(item);
+                const cardCls = isNew
+                    ? 'bg-blue-50/70 dark:bg-blue-950/20 border-blue-200/60 dark:border-blue-800/40 hover:border-blue-300 dark:hover:border-blue-700/50 hover:bg-blue-100/60 dark:hover:bg-blue-900/30 active:bg-blue-100 dark:active:bg-blue-900/40'
+                    : 'bg-white dark:bg-neutral-900 border-gray-200 dark:border-neutral-800 hover:border-gray-300 dark:hover:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-800 active:bg-gray-100 dark:active:bg-neutral-700';
+                const newBadge = isNew ? '<span class="bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400 px-2 py-0.5 rounded text-xs font-medium">New</span>' : '';
 
-                return `<div data-url="${escapeAttr(item.url)}" class="cursor-pointer active:scale-[0.99] bg-white dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg p-3 sm:p-4 mb-3 border-l-4 ${borderCls} hover:border-gray-300 dark:hover:border-neutral-700 hover:bg-gray-50 dark:hover:bg-neutral-800 active:bg-gray-100 dark:active:bg-neutral-700 transition-all duration-150 overflow-hidden">
+                return `<div data-url="${escapeAttr(item.url)}" class="cursor-pointer active:scale-[0.99] ${cardCls} border rounded-lg p-3 sm:p-4 mb-3 border-l-4 ${borderCls} transition-all duration-150 overflow-hidden">
                     <div class="flex justify-between items-start gap-3">
                         <div class="text-base font-semibold"><a href="${escapeHtml(item.url)}" target="_blank" rel="noopener" class="text-gray-900 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400">${escapeHtml(item.title)}</a></div>
                         ${scoreHtml}
                     </div>
                     <div class="mt-2 text-xs text-gray-500 dark:text-gray-400 flex gap-2 flex-wrap items-center">
-                        <span>${escapeHtml(item.source_name)}</span>
+                        ${newBadge}<span>${escapeHtml(item.source_name)}</span>
                         <span class="bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-400 px-2 py-0.5 rounded text-xs">${escapeHtml(typeTag)}</span>
                         ${tierHtml}${tagsHtml}
                         ${dateLabel ? `<span>${dateLabel}</span>` : ''}


### PR DESCRIPTION
## Summary

- Online (static) mode was missing per-card “New” badges and blue highlight styling that the local mode already had
- Use window.isNewItem() to apply blue background tint and “New” tag badge on individual feed cards, matching dashboard.html

## Test plan
- [ ] Open the online/static feed page and verify new items show blue-tinted background + “New” badge
- [ ] Verify older items render with default styling
- [ ] Verify filter bar badge counts still work