### PR TITLE
Fix new-item detection to prefer fetched_at

### DIFF
--- a/static/badges.js
+++ b/static/badges.js
@@ -48,7 +48,7 @@
         });
 
         (items || []).forEach(function(item) {
-            var d = new Date(item.published_at || item.fetched_at);
+            var d = new Date(item.fetched_at || item.published_at);
 
             if (lastSeenDates.dashboard && d > lastSeenDates.dashboard) {
                 if (!hiddenTypes.includes(item.source_type) && !hiddenSources.includes(item.source_name))
@@ -97,7 +97,7 @@
     var _lastSeenCutoff = null;
     window.isNewItem = function(item) {
         if (!_lastSeenCutoff) return false;
-        var d = new Date(item.published_at || item.fetched_at);
+        var d = new Date(item.fetched_at || item.published_at);
         return d > _lastSeenCutoff;
     };
 

--- a/static/index.html
+++ b/static/index.html
@@ -377,7 +377,7 @@
             if (filters.order_by === 'score') return (b.score || 0) - (a.score || 0);
             if (a.source_type === 'luma' && b.source_type !== 'luma') return 1;
             if (b.source_type === 'luma' && a.source_type !== 'luma') return -1;
-            return new Date(b.published_at || b.fetched_at) - new Date(a.published_at || a.fetched_at);
+            return new Date(b.fetched_at || b.published_at) - new Date(a.fetched_at || a.published_at);
         });
     }
 

--- a/tests/run_badges_test.mjs
+++ b/tests/run_badges_test.mjs
@@ -77,9 +77,9 @@ function resetBadges() {
 }
 
 // ── Items ──
-const oldItem = { published_at: '2026-03-10T00:00:00Z', source_type: 'rss', source_name: 'Test' };
-const newItem = { published_at: '2026-03-15T12:00:00Z', source_type: 'rss', source_name: 'Test' };
-const trendingItem = { published_at: '2026-03-15T12:00:00Z', source_type: 'github_trending', source_name: 'Trending' };
+const oldItem = { published_at: '2026-03-10T00:00:00Z', fetched_at: '2026-03-10T00:00:00Z', source_type: 'rss', source_name: 'Test' };
+const newItem = { published_at: '2026-03-15T12:00:00Z', fetched_at: '2026-03-15T12:00:00Z', source_type: 'rss', source_name: 'Test' };
+const trendingItem = { published_at: '2026-03-15T12:00:00Z', fetched_at: '2026-03-15T12:00:00Z', source_type: 'github_trending', source_name: 'Trending' };
 
 // ── Tests ──
 console.log('\nbadges.js tests\n');
@@ -119,14 +119,24 @@ assert(isNewItem(newItem) === false, 'After visit: previously new item is no lon
 assert(elements['badge-dashboard'].classList.contains('hidden'), 'Badge hidden after revisit');
 assert(elements['badge-dashboard-m'].classList.contains('hidden'), 'Mobile badge hidden after revisit');
 
-// 6 — fetched_at fallback
+// 6 — published_at fallback when fetched_at missing
 resetBadges();
 store['ainews_last_seen_dashboard'] = '2026-03-12T00:00:00Z';
 store['ainews_last_seen_trends'] = '2026-03-12T00:00:00Z';
 store['ainews_last_seen_ccc'] = '2026-03-12T00:00:00Z';
-const itemNoPublished = { fetched_at: '2026-03-15T12:00:00Z', source_type: 'rss', source_name: 'Test' };
-computeBadges([itemNoPublished], {}, 'dashboard');
-assert(isNewItem(itemNoPublished) === true, 'isNewItem falls back to fetched_at');
+const itemNoFetched = { published_at: '2026-03-15T12:00:00Z', source_type: 'rss', source_name: 'Test' };
+computeBadges([itemNoFetched], {}, 'dashboard');
+assert(isNewItem(itemNoFetched) === true, 'isNewItem falls back to published_at when fetched_at missing');
+
+// 6b — fetched_at takes priority over published_at (the local-push Twitter bug)
+resetBadges();
+store['ainews_last_seen_dashboard'] = '2026-03-14T00:00:00Z';
+store['ainews_last_seen_trends'] = '2026-03-14T00:00:00Z';
+store['ainews_last_seen_ccc'] = '2026-03-14T00:00:00Z';
+// Tweet was published Mar 10 (old), but fetched Mar 15 (new) — should show as new
+const recentlyFetched = { published_at: '2026-03-10T00:00:00Z', fetched_at: '2026-03-15T12:00:00Z', source_type: 'twitter', source_name: 'Test' };
+computeBadges([recentlyFetched], {}, 'dashboard');
+assert(isNewItem(recentlyFetched) === true, 'Item with old published_at but recent fetched_at is new');
 
 // 7 — Independent page cutoffs
 resetBadges();
@@ -141,7 +151,7 @@ resetBadges();
 store['ainews_last_seen_dashboard'] = '2026-03-12T00:00:00Z';
 store['ainews_last_seen_trends'] = '2026-03-12T00:00:00Z';
 store['ainews_last_seen_ccc'] = '2026-03-12T00:00:00Z';
-const hiddenItem = { published_at: '2026-03-15T12:00:00Z', source_type: 'github_trending', source_name: 'Repo' };
+const hiddenItem = { published_at: '2026-03-15T12:00:00Z', fetched_at: '2026-03-15T12:00:00Z', source_type: 'github_trending', source_name: 'Repo' };
 computeBadges([hiddenItem], { hidden_source_types: ['github_trending'] }, 'dashboard');
 assert(elements['badge-dashboard'].classList.contains('hidden'), 'Hidden source_type excluded from dashboard badge');
 

--- a/tests/test_badges.html
+++ b/tests/test_badges.html
@@ -58,9 +58,9 @@ function resetBadgeElements() {
 
 <script>
 // ── Test helpers ──
-var oldItem = { published_at: '2026-03-10T00:00:00Z', source_type: 'rss', source_name: 'Test' };
-var newItem = { published_at: '2026-03-15T12:00:00Z', source_type: 'rss', source_name: 'Test' };
-var trendingItem = { published_at: '2026-03-15T12:00:00Z', source_type: 'github_trending', source_name: 'Trending' };
+var oldItem = { published_at: '2026-03-10T00:00:00Z', fetched_at: '2026-03-10T00:00:00Z', source_type: 'rss', source_name: 'Test' };
+var newItem = { published_at: '2026-03-15T12:00:00Z', fetched_at: '2026-03-15T12:00:00Z', source_type: 'rss', source_name: 'Test' };
+var trendingItem = { published_at: '2026-03-15T12:00:00Z', fetched_at: '2026-03-15T12:00:00Z', source_type: 'github_trending', source_name: 'Trending' };
 
 // ── Test 1: isNewItem returns false when no computeBadges has run with timestamps ──
 resetLocalStorage();
@@ -96,14 +96,23 @@ assert(isNewItem(newItem) === false, 'After visit: previously new item is no lon
 var badgeEl2 = document.getElementById('badge-dashboard');
 assert(badgeEl2.classList.contains('hidden'), 'Badge is hidden after revisit (0 new items)');
 
-// ── Test 6: isNewItem uses fetched_at fallback ──
+// ── Test 6: isNewItem uses published_at fallback when fetched_at missing ──
 resetBadgeElements();
 localStorage.setItem('ainews_last_seen_dashboard', '2026-03-12T00:00:00Z');
 localStorage.setItem('ainews_last_seen_trends', '2026-03-12T00:00:00Z');
 localStorage.setItem('ainews_last_seen_ccc', '2026-03-12T00:00:00Z');
-var itemNoPublished = { fetched_at: '2026-03-15T12:00:00Z', source_type: 'rss', source_name: 'Test' };
-computeBadges([itemNoPublished], {}, 'dashboard');
-assert(isNewItem(itemNoPublished) === true, 'isNewItem falls back to fetched_at when published_at is missing');
+var itemNoFetched = { published_at: '2026-03-15T12:00:00Z', source_type: 'rss', source_name: 'Test' };
+computeBadges([itemNoFetched], {}, 'dashboard');
+assert(isNewItem(itemNoFetched) === true, 'isNewItem falls back to published_at when fetched_at is missing');
+
+// ── Test 6b: fetched_at takes priority over published_at (the local-push Twitter bug) ──
+resetBadgeElements();
+localStorage.setItem('ainews_last_seen_dashboard', '2026-03-14T00:00:00Z');
+localStorage.setItem('ainews_last_seen_trends', '2026-03-14T00:00:00Z');
+localStorage.setItem('ainews_last_seen_ccc', '2026-03-14T00:00:00Z');
+var recentlyFetched = { published_at: '2026-03-10T00:00:00Z', fetched_at: '2026-03-15T12:00:00Z', source_type: 'twitter', source_name: 'Test' };
+computeBadges([recentlyFetched], {}, 'dashboard');
+assert(isNewItem(recentlyFetched) === true, 'Item with old published_at but recent fetched_at is new');
 
 // ── Test 7: Different pages have independent cutoffs ──
 resetBadgeElements();
@@ -119,7 +128,7 @@ resetBadgeElements();
 localStorage.setItem('ainews_last_seen_dashboard', '2026-03-12T00:00:00Z');
 localStorage.setItem('ainews_last_seen_trends', '2026-03-12T00:00:00Z');
 localStorage.setItem('ainews_last_seen_ccc', '2026-03-12T00:00:00Z');
-var hiddenItem = { published_at: '2026-03-15T12:00:00Z', source_type: 'github_trending', source_name: 'SomeRepo' };
+var hiddenItem = { published_at: '2026-03-15T12:00:00Z', fetched_at: '2026-03-15T12:00:00Z', source_type: 'github_trending', source_name: 'SomeRepo' };
 computeBadges([hiddenItem], { hidden_source_types: ['github_trending'] }, 'dashboard');
 var badgeEl3 = document.getElementById('badge-dashboard');
 assert(badgeEl3.classList.contains('hidden'), 'Hidden source_type items do not increment dashboard badge');


### PR DESCRIPTION
## Summary
- **Bug**: Online/static mode used `published_at` to detect new items, but tweets fetched via `local-push.sh` have old `published_at` timestamps (when the tweet was posted, not when we fetched it). This caused freshly-fetched Twitter items to never show the "New" badge or blue highlight.
- **Fix**: Changed `badges.js` to prefer `fetched_at` over `published_at` for new-item detection, matching the local mode (Jinja template) behaviour.
- **Also fixed**: Sort comparator in `index.html` had the same `published_at`-first bug — freshly-fetched tweets would sort to the wrong position.
- **Tests**: Added regression test (6b) covering the exact bug scenario (old `published_at` + recent `fetched_at`). Updated all test items to include both timestamp fields. Synced `test_badges.html` with `run_badges_test.mjs`.

## Test plan
- [x] `node tests/run_badges_test.mjs` — 17/17 pass
- [x] `uv run pytest` — 220/220 pass
- [x] `uv run ruff check src/` — clean
- [ ] Manual: visit Vercel site after a `local-push` Twitter update, verify new tweets show blue highlight and "New" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)