### PR TITLE
Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # MyFocalAI
 
+[![CI](https://github.com/YanCheng-go/my-focal-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/YanCheng-go/my-focal-ai/actions/workflows/ci.yml)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
+[![License: CC BY-NC 4.0](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey)](LICENSE)
+[![Code style: Ruff](https://img.shields.io/badge/code%20style-ruff-000000)](https://docs.astral.sh/ruff/)
+
 Personal news intelligence system that aggregates AI content from curated sources (RSS, YouTube, Twitter, arXiv, events, GitHub trending, AI tools trending, agent skills), scores relevance using LLM, and serves a web dashboard. Runs locally with Ollama (free) or deployed to Vercel with Claude API scoring.
 
 | Feeds | Admin |


### PR DESCRIPTION
## Summary
- Add CI status, Python version, license, and Ruff code style badges to README header

## Test plan
- [ ] Verify badges render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)