### PR TITLE
Make RSSHub optional in fetch workflow

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -11,18 +11,18 @@ permissions:
 jobs:
   fetch:
     runs-on: ubuntu-latest
-    services:
-      rsshub:
-        image: diygod/rsshub:2026-03-20
-        ports:
-          - 1200:1200
-        options: >-
-          --health-cmd "wget -qO- http://localhost:1200 || exit 1"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
     steps:
       - uses: actions/checkout@v6
+
+      # Run RSSHub as a regular container so failure doesn't abort the job.
+      # Non-RSS sources (trending scrapers, events) still run without it.
+      - name: Start RSSHub
+        continue-on-error: true
+        run: |
+          docker run -d --name rsshub -p 1200:1200 diygod/rsshub:latest
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:1200 > /dev/null && break || sleep 2
+          done
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary
- Replace RSSHub service container with a regular `docker run` step + `continue-on-error: true`
- Use `diygod/rsshub:latest` instead of pinned `2026-03-20` tag
- Non-RSS sources (aitmpl, skillssh, github trending, events) now run even when RSSHub fails

## Context
The `2026-03-20` RSSHub image fails its health check in CI, causing the entire fetch workflow to abort. This means zero data gets fetched — including sources that don't need RSSHub at all.

## Test plan
- [ ] Trigger workflow manually and verify non-RSS sources fetch successfully
- [ ] Verify RSS feeds still work when RSSHub starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)