### PR TITLE
Make RSSHub container optional in fetch workflow

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -11,18 +11,18 @@ permissions:
 jobs:
   fetch:
     runs-on: ubuntu-latest
-    services:
-      rsshub:
-        image: diygod/rsshub:2026-03-20
-        ports:
-          - 1200:1200
-        options: >-
-          --health-cmd "wget -qO- http://localhost:1200 || exit 1"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
     steps:
       - uses: actions/checkout@v6
+
+      # Run RSSHub as a regular container so failure doesn't abort the job.
+      # Non-RSS sources (trending scrapers, events) still run without it.
+      - name: Start RSSHub
+        continue-on-error: true
+        run: |
+          docker run -d --name rsshub -p 1200:1200 diygod/rsshub:latest
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:1200 > /dev/null && break || sleep 2
+          done
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary
- Move RSSHub from a GitHub Actions service container to a regular `docker run` step with `continue-on-error: true`
- Non-RSS sources (trending scrapers, events) now still run even if RSSHub fails to start
- Replaces pinned image tag with `latest` for simpler maintenance

## Test plan
- [ ] Trigger fetch workflow manually — verify it completes even if RSSHub image pull fails
- [ ] Verify RSS-based sources still fetch when RSSHub starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)