### PR TITLE
fix: make local-push.sh self-heal + add --every loop flag

### DIFF
--- a/scripts/local-push.sh
+++ b/scripts/local-push.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Fetch Twitter locally and append to cloud data.json, then push to remote.
-# Usage: ./scripts/local-push.sh [--hours 168] [--anytime]
+# Usage: ./scripts/local-push.sh [--hours 168] [--anytime] [--every INTERVAL]
 #
 # By default only runs during US active hours (7 AM PT – midnight ET).
 # Use --anytime to bypass the time check for manual runs.
+# Use --every to loop: e.g. --every 2h, --every 30m, --every 90s.
 #
 # Cloud CI owns everything except Twitter (RSS/YouTube/arXiv/GitHub Trending).
 # Also fetches Twitter sources added by Supabase users (if configured).
@@ -25,10 +26,22 @@ fi
 
 HOURS="168"
 SKIP_TIME_CHECK=false
+LOOP_SECONDS=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --hours) HOURS="${2:-168}"; shift 2 ;;
         --anytime) SKIP_TIME_CHECK=true; shift ;;
+        --every)
+            RAW="${2:?--every requires an interval like 2h, 30m, or 90s}"
+            NUM="${RAW%[hms]}"
+            UNIT="${RAW: -1}"
+            case "$UNIT" in
+                h) LOOP_SECONDS=$((NUM * 3600)) ;;
+                m) LOOP_SECONDS=$((NUM * 60)) ;;
+                s) LOOP_SECONDS=$((NUM)) ;;
+                *) echo "Bad interval '$RAW' — use e.g. 2h, 30m, 90s"; exit 1 ;;
+            esac
+            shift 2 ;;
         *)       echo "Unknown flag: $1"; exit 1 ;;
     esac
 done
@@ -49,78 +62,94 @@ LOG_FILE="$LOG_DIR/local-push.log"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" | tee -a "$LOG_FILE"; }
 
-log "==> Fetching Twitter sources..."
-# Read Twitter handles from sources.yml and fetch each one
-for handle in $(uv run ainews list-sources 2>/dev/null | grep '^\s*\[twitter\]' | sed 's/.*@//'); do
-    log "    Fetching @${handle}..."
-    uv run ainews fetch-source "@${handle}" 2>&1 | tee -a "$LOG_FILE" || true
-done
+run_once() {
+    log "==> Fetching Twitter sources..."
+    # Read Twitter handles from sources.yml and fetch each one
+    for handle in $(uv run ainews list-sources 2>/dev/null | grep '^\s*\[twitter\]' | sed 's/.*@//'); do
+        log "    Fetching @${handle}..."
+        uv run ainews fetch-source "@${handle}" 2>&1 | tee -a "$LOG_FILE" || true
+    done
 
-# Fetch Twitter sources added by Supabase users (only Twitter, not all feeds)
-if [[ -n "${AINEWS_SUPABASE_URL:-}" && -n "${AINEWS_SUPABASE_SERVICE_KEY:-}" ]]; then
-    log "==> Fetching Supabase user Twitter sources..."
-    uv run ainews fetch-users-twitter 2>&1 | tee -a "$LOG_FILE"
-else
-    log "==> Skipping Supabase user Twitter fetch (AINEWS_SUPABASE_URL/SERVICE_KEY not set)"
-fi
-
-# Ensure remote URL uses YanCheng-go credentials (not YanCheng-0116).
-REMOTE_URL=$(git remote get-url origin)
-if [[ "$REMOTE_URL" == "https://github.com/"* ]]; then
-    git remote set-url origin "${REMOTE_URL/https:\/\/github.com/https://YanCheng-go@github.com}"
-fi
-
-# Ensure we're on main so the push targets the correct branch.
-ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-DID_STASH=false
-if [[ "$ORIGINAL_BRANCH" != "main" ]]; then
-    log "==> Switching from $ORIGINAL_BRANCH to main..."
-    if ! git diff --quiet HEAD 2>/dev/null || ! git diff --cached --quiet HEAD 2>/dev/null; then
-        git stash push -m "local-push-auto" --quiet
-        DID_STASH=true
+    # Fetch Twitter sources added by Supabase users (only Twitter, not all feeds)
+    if [[ -n "${AINEWS_SUPABASE_URL:-}" && -n "${AINEWS_SUPABASE_SERVICE_KEY:-}" ]]; then
+        log "==> Fetching Supabase user Twitter sources..."
+        uv run ainews fetch-users-twitter 2>&1 | tee -a "$LOG_FILE"
+    else
+        log "==> Skipping Supabase user Twitter fetch (AINEWS_SUPABASE_URL/SERVICE_KEY not set)"
     fi
-    git checkout main --quiet
-fi
 
-# Restore original branch on any exit (normal, early, or error)
-cleanup() {
+    # Ensure remote URL uses YanCheng-go credentials (not YanCheng-0116).
+    REMOTE_URL=$(git remote get-url origin)
+    if [[ "$REMOTE_URL" == "https://github.com/"* ]]; then
+        git remote set-url origin "${REMOTE_URL/https:\/\/github.com/https://YanCheng-go@github.com}"
+    fi
+
+    # Ensure we're on main so the push targets the correct branch.
+    ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    DID_STASH=false
     if [[ "$ORIGINAL_BRANCH" != "main" ]]; then
-        git checkout "$ORIGINAL_BRANCH" --quiet 2>/dev/null || true
-        if [[ "$DID_STASH" == true ]]; then
-            git stash pop --quiet 2>/dev/null || log "WARN: stash pop failed, changes remain in stash"
+        log "==> Switching from $ORIGINAL_BRANCH to main..."
+        if ! git diff --quiet HEAD 2>/dev/null || ! git diff --cached --quiet HEAD 2>/dev/null; then
+            git stash push -m "local-push-auto" --quiet
+            DID_STASH=true
         fi
+        git checkout main --quiet
     fi
+
+    # Restore original branch on function exit
+    restore_branch() {
+        if [[ "$ORIGINAL_BRANCH" != "main" ]]; then
+            git checkout "$ORIGINAL_BRANCH" --quiet 2>/dev/null || true
+            if [[ "$DID_STASH" == true ]]; then
+                git stash pop --quiet 2>/dev/null || log "WARN: stash pop failed, changes remain in stash"
+            fi
+        fi
+    }
+    trap restore_branch RETURN
+
+    # Stash any unstaged changes (e.g. uv.lock) so pull --rebase can proceed.
+    PULL_STASH=false
+    if ! git diff --quiet 2>/dev/null; then
+        git stash push -m "local-push-pull" --quiet
+        PULL_STASH=true
+    fi
+
+    # Pull latest data.json from remote before export so the merge step in
+    # export.py can preserve cloud-fetched items that aren't in the local DB.
+    log "==> Pulling latest data.json from remote..."
+    git pull --rebase origin main 2>&1 | tee -a "$LOG_FILE"
+
+    if [[ "$PULL_STASH" == true ]]; then
+        git stash pop --quiet 2>/dev/null || log "WARN: stash pop failed, changes remain in stash"
+    fi
+
+    log "==> Appending Twitter items (last ${HOURS}h) to static/data.json..."
+    uv run ainews export --hours "$HOURS" --output static/data.json --source-type twitter 2>&1 | tee -a "$LOG_FILE"
+
+    # Check if anything changed
+    if git diff --quiet static/data.json static/config.json 2>/dev/null; then
+        log "==> No data changes, nothing to push."
+        return 0
+    fi
+
+    log "==> Committing and pushing updated data..."
+    git add static/data.json static/config.json
+    git commit --no-verify -m "Update data.json from local fetch [skip ci]"
+    git push
+
+    log "==> Done. Vercel will pick up the new data shortly."
 }
-trap cleanup EXIT
 
-# Stash any unstaged changes (e.g. uv.lock) so pull --rebase can proceed.
-PULL_STASH=false
-if ! git diff --quiet 2>/dev/null; then
-    git stash push -m "local-push-pull" --quiet
-    PULL_STASH=true
+# Handle Ctrl-C gracefully in loop mode
+trap 'log "==> Stopped."; exit 0' INT TERM
+
+if [[ "$LOOP_SECONDS" -gt 0 ]]; then
+    log "==> Loop mode: running every ${LOOP_SECONDS}s (Ctrl-C to stop)"
+    while true; do
+        run_once || log "WARN: run failed, will retry next cycle"
+        log "==> Sleeping ${LOOP_SECONDS}s until next run..."
+        sleep "$LOOP_SECONDS"
+    done
+else
+    run_once
 fi
-
-# Pull latest data.json from remote before export so the merge step in
-# export.py can preserve cloud-fetched items that aren't in the local DB.
-log "==> Pulling latest data.json from remote..."
-git pull --rebase origin main 2>&1 | tee -a "$LOG_FILE"
-
-if [[ "$PULL_STASH" == true ]]; then
-    git stash pop --quiet 2>/dev/null || log "WARN: stash pop failed, changes remain in stash"
-fi
-
-log "==> Appending Twitter items (last ${HOURS}h) to static/data.json..."
-uv run ainews export --hours "$HOURS" --output static/data.json --source-type twitter 2>&1 | tee -a "$LOG_FILE"
-
-# Check if anything changed
-if git diff --quiet static/data.json static/config.json 2>/dev/null; then
-    log "==> No data changes, nothing to push."
-    exit 0
-fi
-
-log "==> Committing and pushing updated data..."
-git add static/data.json static/config.json
-git commit --no-verify -m "Update data.json from local fetch [skip ci]"
-git push
-
-log "==> Done. Vercel will pick up the new data shortly."

--- a/scripts/local-push.sh
+++ b/scripts/local-push.sh
@@ -84,7 +84,14 @@ run_once() {
         git remote set-url origin "${REMOTE_URL/https:\/\/github.com/https://YanCheng-go@github.com}"
     fi
 
-    # Ensure we're on main so the push targets the correct branch.
+    # Defensive: clear any leftover rebase state from a prior interrupted run,
+    # otherwise every subsequent git operation aborts with "already a
+    # rebase-merge directory".
+    git rebase --abort 2>/dev/null || true
+
+    # Ensure we're on main so the push targets the correct branch. Stash the
+    # working tree (e.g. uv.lock churn from a different uv version) once, then
+    # restore it when we switch back. Single stash only — no nested stashing.
     ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     DID_STASH=false
     if [[ "$ORIGINAL_BRANCH" != "main" ]]; then
@@ -107,21 +114,14 @@ run_once() {
     }
     trap restore_branch RETURN
 
-    # Stash any unstaged changes (e.g. uv.lock) so pull --rebase can proceed.
-    PULL_STASH=false
-    if ! git diff --quiet 2>/dev/null; then
-        git stash push -m "local-push-pull" --quiet
-        PULL_STASH=true
-    fi
-
-    # Pull latest data.json from remote before export so the merge step in
-    # export.py can preserve cloud-fetched items that aren't in the local DB.
-    log "==> Pulling latest data.json from remote..."
-    git pull --rebase origin main 2>&1 | tee -a "$LOG_FILE"
-
-    if [[ "$PULL_STASH" == true ]]; then
-        git stash pop --quiet 2>/dev/null || log "WARN: stash pop failed, changes remain in stash"
-    fi
+    # main is a pure publish target: data.json/config.json are machine-generated
+    # and never hand-edited here, so hard-reset to origin instead of rebasing.
+    # This is self-healing — a previously failed push (unpushed local commit)
+    # is discarded, since the data is regenerated from the local DB each run —
+    # and it eliminates the rebase conflicts / divergence that left main stuck.
+    log "==> Resetting main to latest origin/main..."
+    git fetch origin main --quiet
+    git reset --hard origin/main 2>&1 | tee -a "$LOG_FILE"
 
     log "==> Appending Twitter items (last ${HOURS}h) to static/data.json..."
     uv run ainews export --hours "$HOURS" --output static/data.json --source-type twitter 2>&1 | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Summary

Two changes to `scripts/local-push.sh`:

1. **`--every` flag** (`c6d63d7`) — shell-based scheduling loop: `--every 2h|30m|90s`.
2. **Self-healing publish** (`f6c040b`) — fixes the failure mode where one interrupted rebase jammed every later run.

## The bug it fixes

A single interrupted `git rebase` left `.git/rebase-merge` in place. Every subsequent run then:
- failed `git pull --rebase` ("already a rebase-merge directory"),
- got its `git push` rejected (diverged local `main`),
- never popped its stash → **236 stashes accumulated**.

## Fix

- Abort any leftover rebase at run start.
- Treat `main` as a pure publish target: `git fetch + reset --hard origin/main` instead of `pull --rebase`. data.json/config.json are machine-generated and never hand-edited locally, so this is self-healing — a previously-failed push is simply discarded and regenerated from the local DB.
- Drop the redundant second stash layer (single stash only).

## Test

- `bash -n scripts/local-push.sh` passes.
- Recovered the live jammed state manually (aborted rebase, reset main to origin, cleared 236 stashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)