### PR TITLE
chore: group dependabot updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      python:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +19,7 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `groups:` to `.github/dependabot.yml` so dependabot batches bumps into one grouped PR per ecosystem instead of one-per-package.

- **python** group (`pip`/`uv`) → single weekly PR
- **actions** group (`github-actions`) → single weekly PR

## Why

16 open dependabot PRs (#200–#220), many for single packages. Grouping collapses these into 2 rolling PRs, cutting review/CI noise.

## Note

Existing per-package PRs stay open until their next dependabot cycle, when they get folded into the grouped PR. The closed/superseded ones (covered by #216) won't reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)