### PR TITLE
ci: migrate release-drafter to v7 with write permission

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,17 +3,15 @@ name: Release Drafter
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
release-drafter v7 creates the draft release itself, requiring `contents: write` (v6 tolerated `contents: read`). Without it: `Resource not accessible by integration`.

- Bump `release-drafter/release-drafter` v6 → v7
- `permissions: contents: write`
- Drop `pull_request` trigger — it only ran the draft job, which can't work on the read-only token dependabot/fork PRs get anyway

Supersedes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)